### PR TITLE
fix: actions and pytest strictness

### DIFF
--- a/.github/actions/setup-triqs/action.yml
+++ b/.github/actions/setup-triqs/action.yml
@@ -25,7 +25,7 @@ runs:
 
   steps:
   - name: Setup Python ${{ inputs.python-version }}
-    uses: actions/setup-python@v4
+    uses: actions/setup-python@v5
     with:
       python-version: ${{ inputs.python-version }}
       allow-prereleases: true
@@ -106,7 +106,7 @@ runs:
       
   - name: Cache build TRIQS
     id: build-triqs
-    uses: actions/cache@v3
+    uses: actions/cache@v4
     with:
       path: triqs
       key: triqs-${{ inputs.os }}-${{ inputs.python-version }} ${{ inputs.cc }}-${{ inputs.llvm }}-${{ inputs.gcc-version }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - {os: "ubuntu-22.04", python-version: "3.10", cc: "gcc", cxx: "g++", llvm: "15", gcc-version: "12"}
-          - {os: "ubuntu-22.04", python-version: "3.11", cc: "gcc", cxx: "g++", llvm: "15", gccversion: "12"}
+          - {os: "ubuntu-22.04", python-version: "3.11", cc: "gcc", cxx: "g++", llvm: "15", gcc-version: "12"}
           #- {os: "ubuntu-22.04", python-version: "3.10", cc: "clang", cxx: "clang++", llvm: "15", gcc-version: "12"}
           #- {os: "ubuntu-22.04", python-version: "3.11", cc: "clang", cxx: "clang++", llvm: "15", gcc-version: "12"}
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         include:
           - {os: "ubuntu-22.04", python-version: "3.10", cc: "gcc", cxx: "g++", llvm: "15", gcc-version: "12"}
           - {os: "ubuntu-22.04", python-version: "3.11", cc: "gcc", cxx: "g++", llvm: "15", gcc-version: "12"}
+          - {os: "ubuntu-22.04", python-version: "3.12", cc: "gcc", cxx: "g++", llvm: "15", gcc-version: "12"}
           #- {os: "ubuntu-22.04", python-version: "3.10", cc: "clang", cxx: "clang++", llvm: "15", gcc-version: "12"}
           #- {os: "ubuntu-22.04", python-version: "3.11", cc: "clang", cxx: "clang++", llvm: "15", gcc-version: "12"}
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - {os: "ubuntu-22.04", python-version: "3.10", cc: "gcc", cxx: "g++", llvm: "15", gcc-version: "12"}
-          #- {os: "ubuntu-22.04", python-version: "3.11", cc: "gcc", cxx: "g++", llvm: "15", gccversion: "12"}
+          - {os: "ubuntu-22.04", python-version: "3.11", cc: "gcc", cxx: "g++", llvm: "15", gccversion: "12"}
           #- {os: "ubuntu-22.04", python-version: "3.10", cc: "clang", cxx: "clang++", llvm: "15", gcc-version: "12"}
           #- {os: "ubuntu-22.04", python-version: "3.11", cc: "clang", cxx: "clang++", llvm: "15", gcc-version: "12"}
   

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ _build
 
 # Visual Studio Code
 .vscode
+
+src/risb/version.py

--- a/docs/tutorials/self-consistent.md
+++ b/docs/tutorials/self-consistent.md
@@ -230,9 +230,9 @@ input initial guesses to the solution to the self-consistent loop. Often a
 reasonable initial guess is to choose $\mathcal{R}$ as the identity and 
 $\lambda$ as the zero matrix.
 
-There is a helper function that constructs $\hat{H}^{\mathrm{qp}}$ and 
-returns its eigenvalues and eigenvectors at each $k$-point on the finite 
-grid.
+There is a helper function that constructs $\hat{H}^{\mathrm{qp}}$, and 
+it is simple to get its eigenvalues and eigenvectors at each $k$-point on the 
+finite grid.
 
 ```python
 from risb import helpers
@@ -240,7 +240,8 @@ from risb import helpers
 energies_qp = dict()
 bloch_vector_qp = dict()
 for bl, bl_size in gf_struct
-    energies_qp[bl], bloch_vector_qp[bl] = helpers.get_h_qp(R[bl], Lambda[bl], h0_kin_k[bl])
+    h_qp = helpers.get_h_qp(R[bl], Lambda[bl], h0_kin_k[bl])
+    energies_qp[bl], bloch_vector_qp[bl] = np.linalg.eigh(h_qp)
 ```
 
 ## D: Setup k-integrator function

--- a/examples/hubbard.py
+++ b/examples/hubbard.py
@@ -4,10 +4,12 @@ from triqs.lattice.tight_binding import TBLattice, BravaisLattice, BrillouinZone
 from triqs.operators import Operator, n
 from triqs.operators.util.op_struct import set_operator_structure
 from triqs.operators.util.observables import S2_op, N_op
+from triqs.gf import BlockGf, MeshImFreq, MeshProduct
 
 from risb import LatticeSolver
 from risb.kweight import SmearingKWeight
 from risb.embedding import EmbeddingAtomDiag
+from risb.helpers_triqs import get_sigma_w, get_g_qp_k_w, get_g_k_w, get_g_w_loc
 
 import matplotlib.pyplot as plt
 
@@ -82,7 +84,40 @@ for U in U_arr:
     total_number.append( embedding.overlap(total_number_Op) )
     total_spin.append( embedding.overlap(total_spin_Op) )
     Z.append(S.Z[0]['up'][0,0])
+    
+    if np.abs(U - 3.5) < 1e-10:
+        # Some different ways to construct some Green's functions
+        mu = kweight.mu
 
+        # Non-interacting lattice Green's function
+        iw_mesh = MeshImFreq(beta=beta, S='Fermion', n_max=64)
+        k_iw_mesh = MeshProduct(mk, iw_mesh)
+        G0_k_iw = BlockGf(mesh=k_iw_mesh, gf_struct=gf_struct)
+        for bl, gf in G0_k_iw:
+            e_k = tbl.fourier(mk)
+            for k, iw in gf.mesh:
+                gf[k,iw] = 1 / (iw - e_k[k] + mu)
+
+        # Quasiparticle lattice Green's function, local self-energy, lattice Green's function
+        G_qp_k_iw = get_g_qp_k_w(gf_struct=gf_struct, mesh=k_iw_mesh, h0_kin_k=S.h0_kin_k, Lambda=S.Lambda[0], R=S.R[0], mu=mu)
+        Sigma_iw = get_sigma_w(mesh=iw_mesh, gf_struct=gf_struct, Lambda=S.Lambda[0], R=S.R[0], mu=mu)
+        G_k_iw = get_g_k_w(g0_k_w=G0_k_iw, sigma_w=Sigma_iw)
+        G_k_iw2 = get_g_k_w(g_qp_k_w=G_qp_k_iw, R=S.R[0])
+
+        # Local Green's functions integrated over k
+        G0_iw_loc = get_g_w_loc(G0_k_iw)
+        G_qp_iw_loc = get_g_w_loc(G_qp_k_iw)
+        G_iw_loc = get_g_w_loc(G_k_iw)
+        G_iw_loc2 = get_g_w_loc(G_k_iw2)
+        
+        # Filling of physical electron scales with Z
+        print("G0:", G0_iw_loc.total_density().real)
+        print("G_qp:", G_qp_iw_loc.total_density().real)
+        print("G:", G_iw_loc.total_density().real)
+        print("G2:", G_iw_loc2.total_density().real)
+        print("Z:", S.Z[0]['up'][0,0])
+        print()
+        
 fig, axis = plt.subplots(1,2)
 axis[0].plot(U_arr, Z, '-ok')
 axis[0].plot(U_arr, -0.5 + 0.5 * np.sqrt( 1 + 4*np.array(total_spin) ), '-ok')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,7 @@ minversion = "7.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
-  "ignore:::.*triqs*",
-  "error",
+  "ignore:::triqs.*:",
 ]
 log_cli_level = "info"
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
   "ignore:::triqs.*:",
+  "error",
 ]
 log_cli_level = "info"
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,7 @@ minversion = "7.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
-  "ignore:::triqs.*:",
-  "error",
+  "error:::risb",
 ]
 log_cli_level = "info"
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ minversion = "7.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
-    "ignore:invalid escape sequence:DeprecationWarning",
-    "error",
+  "ignore:::.*triqs*",
+  "error",
 ]
 log_cli_level = "info"
 testpaths = [

--- a/src/risb/helpers.py
+++ b/src/risb/helpers.py
@@ -248,26 +248,24 @@ def get_h_qp(R : np.ndarray,
              h0_kin_k : np.ndarray, 
              mu : float = 0) -> tuple[ np.ndarray, np.ndarray ]:
     """
-    Construct eigenvalues and eigenvectors of the quasiparticle Hamiltonian.
+    Construct the quasiparticle Hamiltonian.
     
     Parameters
     ----------
     R : numpy.ndarray
-        Renormalization matrix) from electrons to quasiparticles.
+        Renormalization matrix) from electrons to quasiparticles
     Lambda : numpy.ndarray
         Correlation potential of quasiparticles.
     h0_kin_k : numpy.ndarray
         Single-particle dispersion between local clusters. Indexed as 
-        k, orb_i, orb_j.
+        k, orb_i, orb_j
     mu : float, optional
-        Chemical potential.
+        Chemical potential
 
     Return
     ------
-    eigenvalues : numpy.ndarray
-        Indexed as k, band.
-    eigenvectors : numpy.ndarray
-        Indexed as k, each column an eigenvector.
+    h_qp : numpy.ndarray
+        Indexed as k, orb_i, orb_j
     
     Notes
     -----
@@ -280,8 +278,9 @@ def get_h_qp(R : np.ndarray,
         (Lambda - mu*np.eye(Lambda.shape[0]))
     if not np.allclose(h_qp, np.swapaxes(h_qp, 1, 2).conj()):
         warnings.warn("H_qp is not Hermitian !", RuntimeWarning)
-    eig, vec = np.linalg.eigh(h_qp)
-    return (eig, vec)
+    #eig, vec = np.linalg.eigh(h_qp)
+    #return (eig, vec)
+    return h_qp
 
 def get_h0_kin_k_R(R : np.ndarray, 
                    h0_kin_k : np.ndarray, 

--- a/src/risb/solve_lattice.py
+++ b/src/risb/solve_lattice.py
@@ -436,7 +436,8 @@ class LatticeSolver:
         h0_k_R = dict()
         #R_h0_k_R = dict()
         for bl in self.h0_kin_k.keys():
-            self.energies_qp[bl], self.bloch_vector_qp[bl] = helpers.get_h_qp(self.R_full[bl], self.Lambda_full[bl], self.h0_kin_k[bl])
+            h_qp = helpers.get_h_qp(self.R_full[bl], self.Lambda_full[bl], self.h0_kin_k[bl])
+            self.energies_qp[bl], self.bloch_vector_qp[bl] = np.linalg.eigh(h_qp)
             h0_k_R[bl] = helpers.get_h0_kin_k_R(self.R_full[bl], self.h0_kin_k[bl], self.bloch_vector_qp[bl])
             #R_h0_k_R[bl] = helpers.get_R_h0_kin_kR(R_full[bl], self.h0_kin_k[bl], self.bloch_vector_qp[bl])
         

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -20,7 +20,8 @@ def test_get_h_qp(subtests):
     np.fill_diagonal(R, 1)
     Lambda = np.zeros(shape=(2,2))
     np.fill_diagonal(Lambda, 0.5)
-    eig, vec = helpers.get_h_qp(R, Lambda, h0_k)
+    h_qp = helpers.get_h_qp(R, Lambda, h0_k)
+    eig, vec = np.linalg.eigh(h_qp)
     with subtests.test(msg="eigenvalues"):
         assert eig == approx(eig_expected, abs=abs)
     with subtests.test(msg="eigenvectors"):


### PR DESCRIPTION
1. Node minimum version updated for some actions, so updated manually. Also added dependabot to manage github actions.
2. pytest promotes warnings to errors, but was doing this on all 3rd party libraries, i.e., TRIQS has an 'invalid escape sequence' syntax error in its SemiCircular docstring.