### PR TITLE
Made bracketing of chemical potential more robust

### DIFF
--- a/src/risb/kweight/from_triqs_hartree.py
+++ b/src/risb/kweight/from_triqs_hartree.py
@@ -75,8 +75,8 @@ def update_mu(n_target, energies, beta, n_k, smear_function):
     def adjust_brackets(e_min, e_max):
         """
         Gets called if target_function(e_min) and target_function(e_max)
-        have the same sign. Adjusts e_min and e_max until they bracket 
-        the chemical potential (i.e. until target_function(e_min) and 
+        have the same sign. Adjusts e_min and e_max until they bracket
+        the chemical potential (i.e. until target_function(e_min) and
         target_function(e_max) have different signs).
         """
         old_sign = np.sign(target_function(e_min))


### PR DESCRIPTION
Often the brackets of the chemical potential wouldn't work and the calculation would fail, so now if that happens I just adjust the brackets until they work. Infinite recursion is avoided by Python's default recursion limit. I tested it on a problem that used to fail, and now it works seamlessly on my machine.